### PR TITLE
make exit code in failed state a pointer

### DIFF
--- a/generate/swagger.json
+++ b/generate/swagger.json
@@ -527,7 +527,8 @@
     "jobs.FailedState": {
       "properties": {
         "exitCode": {
-          "type": "integer"
+          "type": "integer",
+	  "x-nullable": true
         },
         "message": {
           "type": "string"
@@ -587,14 +588,6 @@
             "$ref": "#/definitions/jobs.Attempt"
           },
           "type": "array"
-        }
-      },
-      "type": "object"
-    },
-    "jobs.SucceededState": {
-      "properties": {
-        "exitCode": {
-          "type": "integer"
         }
       },
       "type": "object"

--- a/models/jobs_failed_state.go
+++ b/models/jobs_failed_state.go
@@ -18,7 +18,7 @@ import (
 type JobsFailedState struct {
 
 	// exit code
-	ExitCode int64 `json:"exitCode,omitempty"`
+	ExitCode *int64 `json:"exitCode,omitempty"`
 
 	// message
 	Message string `json:"message,omitempty"`


### PR DESCRIPTION
by manually adding the `x-nullable` property to the swagger.json

For context, see https://github.com/go-swagger/go-swagger/issues/2166

Part of https://github.com/signadot/signadot/issues/4556

