### PR TITLE
ci: pin GitHub Actions to SHAs (ENG-921)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -20,10 +20,10 @@ jobs:
     name: "Generate Go SDK"
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     - name: Set up Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
       with:
         go-version: ${{ env.GO_VERSION }}
     - name: Generate


### PR DESCRIPTION
## Summary

Pin GitHub Actions in `generate.yml` to full commit SHAs with the major tag preserved as a trailing comment. Add a `github-actions` Dependabot config so SHAs/tags stay updated.

Both refs were on `@v3` (Node 16 runtime, deprecated by GitHub), so the pin doubles as a bump to current stable majors.

### Pinned actions

- `actions/checkout` v3 -> v4 `34e114876b0b11c390a56381ad16ebd13914f8d5`
- `actions/setup-go` v3 -> v5 `40f1582b2485089dde7abd97c1529aa768e1baff`

## Test plan

- [ ] The next push that touches `generate/**` triggers `Generate Go SDK` cleanly and commits the regenerated client/models as before
- [ ] Dependabot picks up the new `github-actions` ecosystem

Refs https://linear.app/signadot/issue/ENG-921
